### PR TITLE
Remove unused `pip` imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@
 import os
 import re
 
-from pip.req import parse_requirements
-from pip.download import PipSession
 from setuptools import setup, find_packages
 
 regexp = re.compile(r'.*__version__ = [\'\"](.*?)[\'\"]', re.S)

--- a/src/prometheus_metrics_proto/__init__.py
+++ b/src/prometheus_metrics_proto/__init__.py
@@ -29,4 +29,4 @@ from .api import (
 from . import utils
 
 
-__version__ = '18.01.01'
+__version__ = '18.01.02'


### PR DESCRIPTION
The unused imports in `setup.py` break package install (from source) when newer versions of `pip` are used